### PR TITLE
Remove GET /api/hello endpoint

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,10 +19,5 @@ app.get('/', (c) => {
   )
 })
 
-app.get('/api/hello', (c) => {
-  return c.json({
-    message: 'Hello, World!'
-  })
-})
 
 export default app


### PR DESCRIPTION
## Summary

- Remove the unused GET /api/hello endpoint as it is no longer needed
- This change was requested in issue #1

## Test plan

- [x] Verify the application builds successfully
- [x] Confirm no other code references the removed endpoint
- [x] Application functionality remains intact

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)